### PR TITLE
Bump from2 and standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "from2": "^1.3.0"
+    "from2": "^2.0.3"
   },
   "devDependencies": {
     "concat-stream": "^1.4.8",
     "covert": "^1.0.1",
-    "standard": "^3.7.2",
+    "standard": "^4.5.2",
     "tape": "^4.0.0"
   },
   "files": [


### PR DESCRIPTION
Updating [from2](https://github.com/hughsk/from2) from v1.x to v2.x, that means [switching from Streams2 to Streams3](https://github.com/hughsk/from2/commit/aaa8d19d767d8bdf90b88050df40af652e5ba518#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L11), requires minor version bump. (I agree on this comment. https://github.com/maxogden/concat-stream/pull/36#issuecomment-112649547)
